### PR TITLE
Known hosts fixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,18 @@ before_install:
         - ssh-keygen -t rsa -f ./test_key -q -N ""
         - docker-compose -f ./ci/port22/docker-compose.yml up -d
         - docker-compose -f ./ci/port25/docker-compose.yml up -d
+        - docker ps
         - ./ci/keyscan.sh
         - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh  
         - dep ensure
 
-
+addons:
+        ssh_known_hosts:
+                - 172.22.0.10
+                - 172.22.0.11
+                - 172.22.0.12
+                - 172.22.0.13
+                - 172.25.0.10:25
+                - 172.25.0.11:25
+                - 172.25.0.12:25
+                - 172.25.0.13:25

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,3 @@ before_install:
         - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh  
         - dep ensure
 
-addons:
-        ssh_known_hosts:
-                - 172.22.0.10
-                - 172.22.0.11
-                - 172.22.0.12
-                - 172.22.0.13
-                - 172.25.0.10:25
-                - 172.25.0.11:25
-                - 172.25.0.12:25
-                - 172.25.0.13:25

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,13 +11,14 @@
     "internal/chacha20",
     "internal/subtle",
     "poly1305",
-    "ssh"
+    "ssh",
+    "ssh/knownhosts"
   ]
   revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ef14b21639fbe1b2016972804e34d4c886e5ce475d13a13bae107b2a7d8cb6f9"
+  inputs-digest = "10e88c78c011692fedd935a6f6b3441404faf4b924abe08d3f8b436d78fbe9d7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ci/keyscan.sh
+++ b/ci/keyscan.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # cluster22 
-ssh-keyscan -v 172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan  172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
 
 # cluster25
-ssh-keyscan -vp 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan -p 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
 
 
 cat $TRAVIS_BUILD_DIR/known_hosts
-
-
 

--- a/ci/keyscan.sh
+++ b/ci/keyscan.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # cluster22 
-ssh-keyscan 172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan -v 172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
 
 # cluster25
-ssh-keyscan -p 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan -vp 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
 
 
 cat $TRAVIS_BUILD_DIR/known_hosts

--- a/ci/keyscan.sh
+++ b/ci/keyscan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # cluster22 
-ssh-keyscan 172.22.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan 172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
 
 # cluster25
 ssh-keyscan -p 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts

--- a/ci/keyscan.sh
+++ b/ci/keyscan.sh
@@ -4,7 +4,7 @@
 ssh-keyscan  172.22.0.{10..13}  > $TRAVIS_BUILD_DIR/known_hosts
 
 # cluster25
-ssh-keyscan -p 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
+ssh-keyscan -p 25 172.25.0.{10..13}  | awk '{print "["$1"]:25 " $2 " " $3}' >> $TRAVIS_BUILD_DIR/known_hosts
 
 
 cat $TRAVIS_BUILD_DIR/known_hosts

--- a/ci/keyscan.sh
+++ b/ci/keyscan.sh
@@ -7,4 +7,7 @@ ssh-keyscan 172.22.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
 ssh-keyscan -p 25 172.25.0.{10..13}  >> $TRAVIS_BUILD_DIR/known_hosts
 
 
+cat $TRAVIS_BUILD_DIR/known_hosts
+
+
 

--- a/node_test.go
+++ b/node_test.go
@@ -10,7 +10,7 @@ import (
 
 const USER = "root"
 
-var dir = os.Getenv("TRAVIS_BUILD_DIR")
+var dir = os.Getenv("HOME") + "/.ssh"
 
 func TestCreateNode(t *testing.T) {
 

--- a/node_test.go
+++ b/node_test.go
@@ -10,7 +10,7 @@ import (
 
 const USER = "root"
 
-var dir = os.Getenv("HOME") + "/.ssh"
+var dir = os.Getenv("TRAVIS_BUILD_DIR")
 
 func TestCreateNode(t *testing.T) {
 

--- a/node_test.go
+++ b/node_test.go
@@ -1,6 +1,7 @@
 package clusterExec
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -62,7 +63,7 @@ func TestGetConfig(t *testing.T) {
 		t.Fail()
 	}
 
-	hostaddress := node.Hostname + ":" + string(node.Port)
+	hostaddress := fmt.Sprintf("%s:%d", node.Hostname, node.Port)
 	client, err := ssh.Dial("tcp", hostaddress, node.Config)
 	if err != nil {
 		t.Log("Failed to generate valid config")

--- a/ssh.go
+++ b/ssh.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 const (
@@ -48,7 +49,7 @@ func (node *ClusterNode) GetConfig() error {
 	var config ssh.ClientConfig
 
 	if len(node.Auth) == 0 {
-		return errors.New("Programming error: No auth method provided, cannot compose ssh configuration")
+		panic("programming error: no auth method provided, cannot compose ssh config")
 	}
 
 	config.User = node.User
@@ -56,10 +57,10 @@ func (node *ClusterNode) GetConfig() error {
 
 	if node.HostKeyCheck {
 		if node.KnownHostsFile == "" {
-			return errors.New("Programming error: no known hosts file name provided")
+			panic("programming error: no known hosts file name provided")
 		}
 		var err error
-		config.HostKeyCallback, err = parseHostKeys(node.Hostname, node.KnownHostsFile)
+		config.HostKeyCallback, err = knownhosts.New(node.KnownHostsFile)
 		if err != nil {
 			return err
 		}
@@ -96,7 +97,7 @@ func parseHostKeys(hostname, keyfile string) (ssh.HostKeyCallback, error) {
 		}
 	}
 	if hostKey == nil {
-		return nil, errors.New("No key found for this host - make sure known_hosts_file is valid")
+		return nil, errors.New("clusterExec: No key found for this host - make sure known_hosts file is valid")
 	}
 	return ssh.FixedHostKey(hostKey), nil
 

--- a/ssh.go
+++ b/ssh.go
@@ -1,11 +1,6 @@
 package clusterExec
 
 import (
-	"bufio"
-	"errors"
-	"os"
-	"strings"
-
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
@@ -70,36 +65,6 @@ func (node *ClusterNode) GetConfig() error {
 
 	node.Config = &config
 	return nil
-
-}
-
-func parseHostKeys(hostname, keyfile string) (ssh.HostKeyCallback, error) {
-	file, err := os.Open(keyfile)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	var hostKey ssh.PublicKey
-	for scanner.Scan() {
-		fields := strings.Split(scanner.Text(), " ")
-		if len(fields) != 3 {
-			continue
-		}
-		if strings.Contains(fields[0], hostname) {
-			var err error
-			hostKey, _, _, _, err = ssh.ParseAuthorizedKey(scanner.Bytes())
-			if err != nil {
-				return nil, err
-			}
-			break
-		}
-	}
-	if hostKey == nil {
-		return nil, errors.New("clusterExec: No key found for this host - make sure known_hosts file is valid")
-	}
-	return ssh.FixedHostKey(hostKey), nil
 
 }
 


### PR DESCRIPTION
- Uses knownhosts.New() to handle multiple known_hosts keys (and it should handle hashed keys also) 

- Travis ssh-keygen doesn't correctly generate a known_hosts entry for systems with non-22 ports. Created an awk wrapper for this. 